### PR TITLE
Bugfix

### DIFF
--- a/subliminal/providers/itasa.py
+++ b/subliminal/providers/itasa.py
@@ -112,7 +112,7 @@ class ItaSAProvider(Provider):
             self.auth_code = root.find('data/user/authcode').text
 
             r = self.session.get('https://www.italiansubs.net/', allow_redirects=True, timeout=30)
-            form = re.search('<form.*?id="form-login".*?>.*?</form>', r.content, re.DOTALL)
+            form = re.search('<form.*?id="form-login".*?>.*?</form>', r.content.decode("utf-8"), re.DOTALL)
             input_matcher = re.finditer('<input.*?name="(.*?)".*?value="(.*?)".*?/>', form.group())
 
             data = {}


### PR DESCRIPTION
Added a fix in order to prevent this error:
```
ERROR:subliminal.core:Unexpected error in provider 'itasa'
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/subliminal/core.py", line 119, in list_subtitles_provider
    return self[provider].list_subtitles(video, provider_languages)
  File "/usr/lib/python3.6/site-packages/subliminal/core.py", line 69, in __getitem__
    provider.initialize()
  File "/usr/lib/python3.6/site-packages/subliminal/providers/itasa.py", line 115, in initialize
    form = re.search('<form.*?id="form-login".*?>.*?</form>', r.content)
  File "/usr/lib/python3.6/re.py", line 182, in search
    return _compile(pattern, flags).search(string)
TypeError: cannot use a string pattern on a bytes-like object
```